### PR TITLE
Add setuptools and setuptools-scm to host requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - python {{ python_min }}
     - pip
     - pytest-runner
+    - setuptools >=61
+    - setuptools-scm >=8
   run:
     - array-api-compat
     - cfgrib >=0.9.10.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 021034ea151e76b75f5be890dc88cf87636b1f456cdd1d39edaa467fbc169366
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 


### PR DESCRIPTION
Setuptools and setuptools-scm are listed in pyproject.toml but are missing from the conda recipe. This causes the built package to have version 0.0.0



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Resolves #81 
<!--
Please add any other relevant info below:
-->
